### PR TITLE
fix: remove extra brackets

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ If you're using version control, you will want to check in this directory.
 
 ## Using
 
-`{{{< qrcode https://jmbuhr.de >}}}`
+`{{< qrcode https://jmbuhr.de >}}`
 
 More examples: <https://jmbuhr.de/quarto-qrcode>
 


### PR DESCRIPTION
This PR remove the extra brackets in the shortcode of the README.md.